### PR TITLE
#upgrade 实现保存图片功能

### DIFF
--- a/lib/pages/check_memo.dart
+++ b/lib/pages/check_memo.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:memo_program/pages/add_memo.dart';
+import 'package:memo_program/services/memo_services.dart';
 import 'package:memo_program/widgets/image_view.dart';
 import 'package:memo_program/widgets/memo_widget.dart';
 import 'package:memo_program/styles/memo_style.dart';
@@ -21,7 +22,7 @@ class _MemoCheckPageState extends State<MemoCheckPage> {
   @override
   void initState() {
     super.initState();
-    memo = widget.memo; // 获取传递的 memo 数据
+    memo = widget.memo;
     viewPic = widget.memo.images.isNotEmpty ? widget.memo.images[0] : '';
   }
   void _viewImage(String path) {
@@ -172,6 +173,18 @@ class _MemoCheckPageState extends State<MemoCheckPage> {
             ),
             if(_isCheck)
               InkWell(
+                onLongPress: () async{
+                  final confirm = await showSavePicDialog(context);
+                  if(confirm ?? false) {
+                    try {
+                      await CURDManager.savePicture(viewPic);
+
+                    } catch(e) {
+                      debugPrint('保存图片遇到错误: $e');
+                    }
+                  }
+
+                },
                 onTap: _closeImageViewer,
                 child: ImageViewerBuilder(
                   path: viewPic,

--- a/lib/services/memo_services.dart
+++ b/lib/services/memo_services.dart
@@ -10,6 +10,25 @@ import '../models/memo.dart';
 import '../widgets/memo_widget.dart';
 
 class CURDManager{
+  static Future<void> savePicture(
+      String originPath,
+      )async {
+    final targetPath = await FilePicker.platform.getDirectoryPath();
+    final now = DateTime.now();
+    //final picFile = File(path);
+    if(targetPath != null) {
+      String optPath = path.join(targetPath,'memoPic_${now.millisecondsSinceEpoch.toString()}.${originPath.split('.').last}');
+      try {
+        print(originPath);
+        print(targetPath);
+        print(optPath);
+        await File(originPath).copy(optPath);
+        print("保存成功");
+      } catch(e){
+        print("图片复制失败：$e");
+      }
+    }
+  }
   static Future<void> saveMemo(
       BuildContext context,
       TextEditingController controller,
@@ -45,40 +64,41 @@ class CURDManager{
       );
     }
   }
-}
-Future<void> deleteMemo(Memo memo) async {
-  final directory = await PathManager.getSavePath();
-  final file = File(path.join(directory, 'memo_${memo.milliseconds}.json'));  // 使用 path.join 来拼接路径
+  static Future<void> deleteMemo(Memo memo) async {
+    final directory = await PathManager.getSavePath();
+    final file = File(path.join(directory, 'memo_${memo.milliseconds}.json'));  // 使用 path.join 来拼接路径
 
-  try {
-    if (await file.exists()) {
-      await file.delete();
-      debugPrint('文件删除成功: ${file.path}');
-    } else {
-      debugPrint('文件不存在: ${file.path}');
-    }
-  } catch (e) {
-    debugPrint('删除失败: $e');
-    rethrow;
-  }
-}
-
-Future<void> handleDeleteMemo({
-  required BuildContext context,
-  required Memo memo,
-  required VoidCallback onSuccess,
-}) async {
-  final confirm = await showDeleteDialog(context);
-  if (confirm ?? false) {
     try {
-      await deleteMemo(memo);
-      onSuccess();
-      debugPrint("删除成功");
+      if (await file.exists()) {
+        await file.delete();
+        debugPrint('文件删除成功: ${file.path}');
+      } else {
+        debugPrint('文件不存在: ${file.path}');
+      }
     } catch (e) {
-      debugPrint('删除操作遇到错误: $e');
+      debugPrint('删除失败: $e');
+      rethrow;
+    }
+  }
+
+  static Future<void> handleDeleteMemo({
+    required BuildContext context,
+    required Memo memo,
+    required VoidCallback onSuccess,
+  }) async {
+    final confirm = await showDeleteDialog(context);
+    if (confirm ?? false) {
+      try {
+        await deleteMemo(memo);
+        onSuccess();
+        debugPrint("删除成功");
+      } catch (e) {
+        debugPrint('删除操作遇到错误: $e');
+      }
     }
   }
 }
+
 
 class PathManager {
   static String? customPath;

--- a/lib/widgets/memo_widget.dart
+++ b/lib/widgets/memo_widget.dart
@@ -147,7 +147,7 @@ class MemoListViewBuilder extends StatelessWidget {
               children: [
                 SlidableAction(
                   onPressed: (context) async{
-                    await handleDeleteMemo(
+                    await CURDManager.handleDeleteMemo(
                       context: context,
                       memo: memo,
                       onSuccess:  MemoConfig.toggleRefresh,
@@ -256,7 +256,7 @@ class DeleteMemoWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       onPressed: () async{
-        await handleDeleteMemo(context: context, memo: memo, onSuccess: (){
+        await CURDManager.handleDeleteMemo(context: context, memo: memo, onSuccess: (){
           Navigator.pop(context);
         });
       },
@@ -264,7 +264,34 @@ class DeleteMemoWidget extends StatelessWidget {
     );
   }
 }
+Future<bool?> showSavePicDialog(BuildContext context) async{
+  return showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: Text('保存图片',style: MemoStyle.titleTextStyle),
+      content: Text('是否要保存此图片？', style: MemoStyle.bodyTextStyle),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.pop(context, false); // 关闭弹窗
+          },
+          child: Text('取消', style: MemoStyle.dialogButtonTextStyle),
+        ),
+        TextButton(
+          onPressed: () {
+            Navigator.pop(context, true); // 关闭弹窗
+          },
+          child: Text('保存', style: MemoStyle.dialogButtonTextStyle),
+        ),
+      ],
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      backgroundColor: Colors.white,
+    ),
 
+  );
+}
 Future<bool?> showDeleteDialog(BuildContext context) async {
   return showDialog<bool>(
     context: context,


### PR DESCRIPTION
查看图片时，监测长摁动作，弹窗确定是否保存图片
图片保存逻辑如下：将该图片的路径String参数传入CURDManager的savePicture中
通过FilePicker.platform.getDirectoryPath()选择路径，将原图片复制到选择的地址中
复制时需要带着新文件的命名，于是规范化命名操作，命名格式采用'memoPic_milliseconds.源文件格式'
源文件格式使用path.split('.').last分离出来